### PR TITLE
不具合修正など

### DIFF
--- a/src/components/user/container/UserIconMenu.tsx
+++ b/src/components/user/container/UserIconMenu.tsx
@@ -69,7 +69,7 @@ const UserIconMenu: VFC<UserIconMenuProps> = (props: UserIconMenuProps) => {
         borderRadius="4px"
         my="5px"
         onClick={() => {
-          router.push(`/${props.user?.display_id}/account/edit`)
+          router.push(`/account/profile`)
         }}
       >
         <Text color="gray.800" fontSize="13px">


### PR DESCRIPTION
■自分のメニューからアカウント設定、で間違ったリンクに飛ぶ問題を修正
1. 先にメニューを作っていて、リンクを仮で書いていたが後から実際のリンクが変更になり
メニューの中のリンクを修正できていなかった。
